### PR TITLE
Support getting shariah compliance reports from Zoya

### DIFF
--- a/src/lib/zoya/index.ts
+++ b/src/lib/zoya/index.ts
@@ -1,9 +1,8 @@
 import { requireEnv } from "@/helpers"
-import { AAOIFIStockReportSchema } from "./types"
+import { StockReportSchema } from "./types"
 import { Mock } from "@/decorators/mock"
 
-const BASE_URL = "https://sandbox-api.zoya.finance/graphql"
-// const BASE_URL = "https://api.zoya.finance/graphql"
+const BASE_URL = "https://api.zoya.finance/graphql"
 const API_KEY = requireEnv("ZOYA_API_KEY")
 
 export class Zoya {
@@ -17,10 +16,8 @@ export class Zoya {
 
   @Mock((json, stocks: string[]) => stocks.map(stock => ({ ...json[Math.floor(Math.random() * json.length)], symbol: stock })))
   async getStockReportBatch(stocks: string[]) {
-    console.time("getStockReportBatch");
-    const dedupedStocks = Array.from(new Set(stocks));
-    const ddd = await Promise.all(dedupedStocks.map(async stock => {
-      console.time(`query ${stock}`);
+    const dedupedStocks = Array.from(new Set(stocks))
+    return Promise.all(dedupedStocks.map(async stock => {
       const query = `
 query {
   advancedCompliance {
@@ -63,17 +60,13 @@ query {
         }
 
         const json: any = await response.json()
-        const obj = AAOIFIStockReportSchema.parse(json.data.advancedCompliance.report)
+        const obj = StockReportSchema.parse(json.data.advancedCompliance.report)
         return obj
       } catch (error) {
         console.error("Fetch failed:", error)
         throw error
-      } finally {
-        console.timeEnd(`query ${stock}`);
       }
-    }));
-    console.timeEnd("getStockReportBatch");
-    return ddd;
+    }))
   }
 }
 

--- a/src/lib/zoya/index.ts
+++ b/src/lib/zoya/index.ts
@@ -1,0 +1,80 @@
+import { requireEnv } from "@/helpers"
+import { AAOIFIStockReportSchema } from "./types"
+import { Mock } from "@/decorators/mock"
+
+const BASE_URL = "https://sandbox-api.zoya.finance/graphql"
+// const BASE_URL = "https://api.zoya.finance/graphql"
+const API_KEY = requireEnv("ZOYA_API_KEY")
+
+export class Zoya {
+  private getHeaders() {
+    return {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: API_KEY,
+    }
+  }
+
+  @Mock((json, stocks: string[]) => stocks.map(stock => ({ ...json[Math.floor(Math.random() * json.length)], symbol: stock })))
+  async getStockReportBatch(stocks: string[]) {
+    console.time("getStockReportBatch");
+    const dedupedStocks = Array.from(new Set(stocks));
+    const ddd = await Promise.all(dedupedStocks.map(async stock => {
+      console.time(`query ${stock}`);
+      const query = `
+query {
+  advancedCompliance {
+    report(input: {
+      symbol: "${stock}",
+      methodology: AAOIFI
+    }) {
+      symbol
+      rawSymbol
+      name
+      figi
+      exchange
+      status
+      reportDate
+      businessScreen
+      financialScreen
+      compliantRevenue
+      nonCompliantRevenue
+      questionableRevenue
+      ... on AAOIFIReport {
+        securitiesToMarketCapRatio
+        debtToMarketCapRatio
+      }
+    }
+  }
+}
+`
+      try {
+        const response = await fetch(
+          BASE_URL,
+          {
+            method: "POST",
+            body: JSON.stringify({ query }),
+            headers: this.getHeaders(),
+            cache: "no-store", // prevents caching
+          }
+        )
+        if (!response.ok) {
+          throw new Error(`Failed to fetch with status ${response.status}`)
+        }
+
+        const json: any = await response.json()
+        const obj = AAOIFIStockReportSchema.parse(json.data.advancedCompliance.report)
+        return obj
+      } catch (error) {
+        console.error("Fetch failed:", error)
+        throw error
+      } finally {
+        console.timeEnd(`query ${stock}`);
+      }
+    }));
+    console.timeEnd("getStockReportBatch");
+    return ddd;
+  }
+}
+
+export default new Zoya()

--- a/src/lib/zoya/mappers.ts
+++ b/src/lib/zoya/mappers.ts
@@ -1,14 +1,27 @@
-import { OverallStatus } from "./types";
+import { OverallStatus } from "./types"
 
 export function toShariahStatus(rawStatus: OverallStatus) {
   switch (rawStatus) {
-    case "COMPLIANT":
-      return "compliant";
-    case "NON_COMPLIANT":
-      return "non_compliant";
-    case "QUESTIONABLE":
-      return "doubtful";
-    case "UNRATED":
-      return "not_covered";
+  case "COMPLIANT":
+    return "compliant"
+  case "NON_COMPLIANT":
+    return "non_compliant"
+  case "QUESTIONABLE":
+    return "doubtful"
+  case "UNRATED":
+    return "not_covered"
+  }
+}
+
+export function toMusaffaStatus(rawStatus: OverallStatus): import("../musaffa/types").OverallStatus {
+  switch (rawStatus) {
+  case "COMPLIANT":
+    return "HALAL"
+  case "NON_COMPLIANT":
+    return "NOT HALAL"
+  case "QUESTIONABLE":
+    return "DOUBTFUL"
+  case "UNRATED":
+    return "NOT COVERED"
   }
 }

--- a/src/lib/zoya/mappers.ts
+++ b/src/lib/zoya/mappers.ts
@@ -1,0 +1,14 @@
+import { OverallStatus } from "./types";
+
+export function toShariahStatus(rawStatus: OverallStatus) {
+  switch (rawStatus) {
+    case "COMPLIANT":
+      return "compliant";
+    case "NON_COMPLIANT":
+      return "non_compliant";
+    case "QUESTIONABLE":
+      return "doubtful";
+    case "UNRATED":
+      return "not_covered";
+  }
+}

--- a/src/lib/zoya/types.ts
+++ b/src/lib/zoya/types.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+const OverallStatus = z.enum([
+  "COMPLIANT",
+  "NON_COMPLIANT",
+  "QUESTIONABLE",
+  "UNRATED",
+]);
+
+export type OverallStatus = z.infer<typeof OverallStatus>;
+
+export const BasicStockReportSchema = z.object({
+  symbol: z.string(), // "AAPL"
+  name: z.string().optional(), // "Apple Inc"
+  exchange: z.string().optional(), // "XNAS"
+  status: OverallStatus,
+  reportDate: z.string().optional(), // "2023-12-10:08:03.420Z"
+});
+
+export type BasicStockReport = z.infer<typeof BasicStockReportSchema>;
+
+export const AdvancedStockReportSchema = BasicStockReportSchema.extend({
+  rawSymbol: z.string(), // "0R0K"
+  figi: z.string().optional(), // "BBG00QDG6DB5"
+  businessScreen: OverallStatus.optional(),
+  financialScreen: OverallStatus.exclude([OverallStatus.Enum.QUESTIONABLE]).optional(),
+  compliantRevenue: z.number().optional(), // 98.34
+  nonCompliantRevenue: z.number().optional(), // 1.66
+  questionableRevenue: z.number().optional(), // 0
+});
+
+export type AdvancedStockReport = z.infer<typeof AdvancedStockReportSchema>;
+
+export const AAOIFIStockReportSchema = AdvancedStockReportSchema.extend({
+  debtToMarketCapRatio: z.number().optional(), // 0.0416
+  securitiesToMarketCapRatio: z.number().optional(), // 0.1145
+});
+
+export type AAOIFIStockReport = z.infer<typeof AAOIFIStockReportSchema>;


### PR DESCRIPTION
This covers the first point in https://github.com/fundpurifier/app/issues/4#issuecomment-1869436523
> - [ ] Implement `lib/zoya/`; the only method that matters is [getStockReportBatch](https://github.com/fundpurifier/app/blob/main/src/lib/musaffa/index.ts?rgh-link-date=2023-12-26T10%3A20%3A17Z#L24-L48)

Note that Zoya doesn't support getting reports for many stocks in a single query, I worked around it by running n queries in parallel.
Depending on how many stocks will get queried at once, we might consider implementing some parallelization limit to make sure we don't send out too many HTTP requests at once and risk some of them timing out/getting dropped.